### PR TITLE
Added dark mode setting

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:app/theme/theme_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:shared_preferences/shared_preferences.dart'
@@ -19,11 +20,40 @@ void main() async {
     projC.projects.add(Project.add(attr.first, dir));
   }
   persistProjects(); // Removes invalid projects automatically
+
+  final darkMode = prefs!.getBool("darkMode") ?? false;
+  themeProvider.toggleTheme(darkMode);
+
   runApp(const MyApp());
 }
 
-class MyApp extends StatelessWidget {
+ThemeProvider themeProvider = ThemeProvider();
+
+class MyApp extends StatefulWidget {
   const MyApp({super.key});
+
+  @override
+  State<StatefulWidget> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  @override
+  void initState() {
+    themeProvider.addListener(themeListener);
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    themeProvider.removeListener(themeListener);
+    super.dispose();
+  }
+
+  themeListener() {
+    if (mounted) {
+      setState(() {});
+    }
+  }
 
   // This widget is the root of your application.
   @override
@@ -32,9 +62,9 @@ class MyApp extends StatelessWidget {
     final c = Get.put(projC);
     return GetMaterialApp(
       title: 'Tutor Tool',
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
-      ),
+      theme: MyThemes.lightTheme,
+      darkTheme: MyThemes.darkTheme,
+      themeMode: themeProvider.themeMode,
       defaultTransition: Transition.fadeIn,
       initialRoute: "/",
       routes: {"/": ((context) => const HomePage())},

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:app/main.dart';
 
 /// Settings Page that allows the user to choose preferences
 class SettingsPage extends StatelessWidget {
@@ -7,7 +8,44 @@ class SettingsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text("Settings")),
-    );
+        appBar: AppBar(title: const Text("Settings")),
+        body: ListView(
+          padding: const EdgeInsets.all(8.0),
+          children: <Widget>[
+            Row(children: [
+              ThemeChangeSwitch(),
+              const Text("Enable Dark Mode"),
+            ]),
+          ],
+        ));
+  }
+}
+
+class ThemeChangeSwitch extends StatefulWidget {
+  const ThemeChangeSwitch({super.key});
+
+  @override
+  State<StatefulWidget> createState() => _ThemeChangeSwitchState();
+}
+
+class _ThemeChangeSwitchState extends State<ThemeChangeSwitch> {
+  bool dark = true;
+
+  @override
+  void initState() {
+    dark = themeProvider.isDarkMode;
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Switch(
+        value: dark,
+        onChanged: (bool value) {
+          themeProvider.toggleTheme(value);
+          setState(() {
+            dark = value;
+          });
+        });
   }
 }

--- a/lib/theme/theme_provider.dart
+++ b/lib/theme/theme_provider.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:app/logic.dart';
+
+class ThemeProvider with ChangeNotifier {
+  ThemeMode _themeMode = ThemeMode.light;
+
+  bool get isDarkMode => _themeMode == ThemeMode.dark;
+  get themeMode => _themeMode;
+
+  Future<void> toggleTheme(bool dark) async {
+    _themeMode = dark ? ThemeMode.dark : ThemeMode.light;
+    notifyListeners();
+    await prefs!.setBool("darkMode", dark);
+  }
+}
+
+class MyThemes {
+  static final ThemeData lightTheme =
+      ThemeData(brightness: Brightness.light, primarySwatch: Colors.blue);
+
+  static final ThemeData darkTheme = ThemeData(brightness: Brightness.dark);
+}


### PR DESCRIPTION
Added a switch in the "Settings" widget that allows the user to toggle between light and dark mode. A ThemeProvider class was created to handle the switching and SharedPreferences was used to save the user's preferred so it persists across sessions.